### PR TITLE
Add puzzle state so we can only see one at a time

### DIFF
--- a/src/components/RoomOne/RoomOne.css
+++ b/src/components/RoomOne/RoomOne.css
@@ -18,7 +18,6 @@
     'plant door door desk radio ';
 }
 
-
 .clock-btn,
 .plant-btn,
 .door-btn,
@@ -37,7 +36,6 @@
   overflow: hidden;
 }
 
-
 .clock-btn:hover,
 .plant-btn:hover,
 .door-btn:hover,
@@ -49,7 +47,6 @@
   transform: scale(0.95);
   cursor: pointer;
 }
-
 
 .clock-btn.disabled,
 .desk-comp-btn.disabled,
@@ -63,7 +60,6 @@
   transform: scale(1);
   pointer-events: none;
 }
-
 
 .clock-btn {
   grid-area: clock;
@@ -132,7 +128,6 @@
 .invert-colors img {
   filter: invert(100%);
 }
-
 
 @media screen and (max-width: 768px) {
   .room {

--- a/src/components/RoomOne/RoomOne.js
+++ b/src/components/RoomOne/RoomOne.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import PuzzleOne from "../PuzzleOne/PuzzleOne";
 import PuzzleThree from "../PuzzleThree/PuzzleThree";
@@ -22,11 +22,7 @@ import { createConsumer } from "@rails/actioncable";
 import { useParams } from "react-router-dom";
 
 export default function RoomOne() {
-  const [showPuzzleOne, setShowPuzzleOne] = useState(false);
-  const [showPuzzleTwo, setShowPuzzleTwo] = useState(false);
-  const [showPuzzleThree, setShowPuzzleThree] = useState(false);
-  const [showPuzzleFour, setShowPuzzleFour] = useState(false);
-  const [showPuzzleFive, setShowPuzzleFive] = useState(false);
+  const [openPopup, setOpenPopup] = useState(null);
   const [lampClicked, setLampClicked] = useState(false);
   const [winConditions, setWinConditions] = useState([]);
   const [isDisabled, setIsDisabled] = useState({
@@ -103,7 +99,6 @@ export default function RoomOne() {
     });
   };
 
-
   useEffect(() => {
     if (winConditions.length === 5) {
       dataSubscription.send({ game_over: true });
@@ -119,44 +114,40 @@ export default function RoomOne() {
     "--room-bg": lampClicked ? "none" : `url(${blueBackground})`,
   };
 
-  const handleClockClick = () => {
-    setShowPuzzleThree(true);
+  const handlePopupOpen = (popupName) => {
+    setOpenPopup(popupName);
   };
-  const handleClosePuzzleThree = () => {
-    setShowPuzzleThree(false);
+
+  const handlePopupClose = () => {
+    setOpenPopup(null);
+  };
+
+  const handleClockClick = () => {
+    handlePopupOpen("puzzleThree");
   };
 
   const handleDeskCompClick = () => {
-    setShowPuzzleOne(true);
+    handlePopupOpen("puzzleOne");
   };
-  const handleClosePuzzleOne = () => {
-    setShowPuzzleOne(false);
-  };
+
   const handleRadioClick = () => {
-    setShowPuzzleTwo(true);
+    handlePopupOpen("puzzleTwo");
   };
-  const handleClosePuzzleTwo = () => {
-    setShowPuzzleTwo(false);
-  };
+
   const handlePlantClick = () => {
-    setShowPuzzleFour(true);
+    handlePopupOpen("puzzleFour");
   };
-  const handleClosePuzzleFour = () => {
-    setShowPuzzleFour(false);
-  };
+
   const handleBikeClick = () => {
-    setShowPuzzleFive(true);
+    handlePopupOpen("puzzleFive");
   };
-  const handleClosePuzzleFive = () => {
-    setShowPuzzleFive(false);
-  };
+
   const handleLampClick = () => {
     setLampClicked(!lampClicked);
   };
 
   return (
     <div>
-      {/* <RoomHeader /> */}
       {showVictoryPage ? (
         <VictoryPage />
       ) : (
@@ -222,48 +213,48 @@ export default function RoomOne() {
           >
             <img className="radio" src={radio} alt="radio" />
           </button>
-          {showPuzzleOne && (
+          {openPopup === "puzzleOne" && (
             <PuzzleOne
               setIsDisabled={() => setPuzzleState("puzzleOne")}
               winConditions={winConditions}
               setWinConditions={setWinConditions}
-              onClose={handleClosePuzzleOne}
+              onClose={handlePopupClose}
               puzzleCompleted={puzzleCompleted}
             />
           )}
-          {showPuzzleTwo && (
+          {openPopup === "puzzleTwo" && (
             <PuzzleTwo
               setIsDisabled={() => setPuzzleState("puzzleTwo")}
               winConditions={winConditions}
               setWinConditions={setWinConditions}
-              onClose={handleClosePuzzleTwo}
+              onClose={handlePopupClose}
               puzzleCompleted={puzzleCompleted}
             />
           )}
-          {showPuzzleThree && (
+          {openPopup === "puzzleThree" && (
             <PuzzleThree
               setIsDisabled={() => setPuzzleState("puzzleThree")}
               winConditions={winConditions}
               setWinConditions={setWinConditions}
-              onClose={handleClosePuzzleThree}
+              onClose={handlePopupClose}
               puzzleCompleted={puzzleCompleted}
             />
           )}
-          {showPuzzleFour && (
+          {openPopup === "puzzleFour" && (
             <PuzzleFour
               setIsDisabled={() => setPuzzleState("puzzleFour")}
               winConditions={winConditions}
               setWinConditions={setWinConditions}
-              onClose={handleClosePuzzleFour}
+              onClose={handlePopupClose}
               puzzleCompleted={puzzleCompleted}
             />
           )}
-          {showPuzzleFive && (
+          {openPopup === "puzzleFive" && (
             <PuzzleFive
               setIsDisabled={() => setPuzzleState("puzzleFive")}
               winConditions={winConditions}
               setWinConditions={setWinConditions}
-              onClose={handleClosePuzzleFive}
+              onClose={handlePopupClose}
               puzzleCompleted={puzzleCompleted}
             />
           )}


### PR DESCRIPTION
What I did:

Made sure puzzles can not overlap

Did this break anything?

- [x] No
- [ ]  Yes

Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.

Checklist:

- [x]  If this code needs to be tested, all tests are passing
- [ ]  The code runs locally
- [ ]  There are comments where clarification/ organization is needed
- [x]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing

Notes:

## Contributors to this pull request:
@judy0ye @Averyberryman 